### PR TITLE
Store window size as `Vec2`

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,8 +1,7 @@
 use bevy::prelude::Vec2;
 
 // Window
-pub const WINDOW_WIDTH: f32 = 720.0;
-pub const WINDOW_HEIGHT: f32 = 480.0;
+pub const WINDOW_SIZE: Vec2 = Vec2::new(720.0, 480.0);
 
 // Sprites
 pub const SPRITE_SHEET_PATH: &str = "assets.png";

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
                         title: "Shooter".into(),
                         resizable: true,
                         focused: true,
-                        resolution: (WINDOW_WIDTH, WINDOW_HEIGHT).into(),
+                        resolution: WINDOW_SIZE.into(),
                         ..default()
                     }),
                     ..default()


### PR DESCRIPTION
This PR stores `WINDOW_WIDTH` and `WINDOW_HEIGHT` as a single `const WINDOW_SIZE: Vec2`.